### PR TITLE
Use HTML5 validation for Spree Checkout, Drop jquery.validate

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -1,6 +1,5 @@
 //= require bootstrap-sprockets
 //= require jquery.payment
-//= require jquery.validate/jquery.validate.min
 //= require spree
 //= require spree/frontend/cart
 //= require spree/frontend/checkout

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -1,7 +1,6 @@
 Spree.ready ($) ->
   Spree.onAddress = () ->
     if ($ '#checkout_form_address').is('*')
-      ($ '#checkout_form_address').validate()
 
       getCountryId = (region) ->
         $('#' + region + 'country select').val()

--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -5,13 +5,13 @@
     <%= form.label :firstname do %>
       <%= Spree.t(:first_name) %><abbr class="required" title="required">*</abbr>
     <% end %>
-    <%= form.text_field :firstname, :class => 'form-control required' %>
+    <%= form.text_field :firstname, :class => 'form-control', required: true %>
   </p>
   <p class="form-group" id=<%="#{address_id}lastname" %>>
     <%= form.label :lastname do %>
       <%= Spree.t(:last_name) %><abbr class="required" title="required">*</abbr>
     <% end %>
-    <%= form.text_field :lastname, :class => 'form-control required' %>
+    <%= form.text_field :lastname, :class => 'form-control', required: true %>
   </p>
   <% if Spree::Config[:company] %>
     <p class="form-group" id=<%="#{address_id}company" %>>
@@ -23,7 +23,7 @@
     <%= form.label :address1 do %>
       <%= Spree.t(:street_address) %><abbr class="required" title="required">*</abbr>
     <% end %>
-    <%= form.text_field :address1, :class => 'form-control  required' %>
+    <%= form.text_field :address1, :class => 'form-control', required: true %>
   </p>
   <p class="form-group" id=<%="#{address_id}address2" %>>
     <%= form.label :address2, Spree.t(:street_address_2) %>
@@ -33,14 +33,14 @@
     <%= form.label :city do %>
       <%= Spree.t(:city) %><abbr class="required" title="required">*</abbr>
     <% end %>
-    <%= form.text_field :city, :class => 'form-control required' %>
+    <%= form.text_field :city, :class => 'form-control', required: true %>
   </p>
   <p class="form-group" id=<%="#{address_id}country" %>>
     <%= form.label :country_id do %>
       <%= Spree.t(:country) %><abbr class="required" title="required">*</abbr>
     <% end %>
     <span id=<%="#{address_id}country-selection" %>>
-      <%= form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'form-control required'} %>
+      <%= form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'form-control', required: true} %>
     </span>
   </p>
 
@@ -55,16 +55,21 @@
          form.collection_select(:state_id, address.country.states,
                             :id, :name,
                             {:include_blank => true},
-                            {:class => have_states ? 'form-control required' : 'form-control hidden',
-                            :disabled => !have_states}) +
+                            {
+                              :class => have_states ? 'form-control' : 'form-control hidden',
+                              :required => have_states,
+                              :disabled => !have_states
+                            }) +
          form.text_field(:state_name,
-                            :class => !have_states ? 'form-control required' : 'form-control hidden',
-                            :disabled => have_states)
+                            :class => !have_states ? 'form-control' : 'form-control hidden',
+                            :required => !have_states,
+                            :disabled => have_states
+                            )
          ].join.gsub('"', "'").gsub("\n", "")
       %>
     </p>
       <noscript>
-        <%= form.text_field :state_name, :class => 'form-control required' %>
+        <%= form.text_field :state_name, :class => 'form-control', required: true %>
       </noscript>
   <% end %>
 
@@ -72,13 +77,13 @@
     <%= form.label :zipcode do %>
       <%= Spree.t(:zip) %><% if address.require_zipcode? %><abbr class="required" title="required">*</abbr><% end %>
     <% end %>
-    <%= form.text_field :zipcode, :class => "form-control #{'required' if address.require_zipcode?}" %>
+    <%= form.text_field :zipcode, :class => "form-control", required: address.require_zipcode? %>
   </p>
   <p class="form-group" id=<%="#{address_id}phone" %>>
     <%= form.label :phone do %>
       <%= Spree.t(:phone) %><% if address.require_phone? %><abbr class="required" title="required">*</abbr><% end %>
     <% end %>
-    <%= form.phone_field :phone, :class => "form-control #{'required' if address.require_phone?}" %>
+    <%= form.phone_field :phone, :class => "form-control", required: address.require_phone? %>
   </p>
   <% if Spree::Config[:alternative_shipping_phone] %>
     <p class="form-group" id=<%="#{address_id}altphone" %>>

--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -44,6 +44,3 @@
   Spree.current_order_token = "<%= @order.guest_token %>"
 </script>
 
-<% if I18n.locale != :en %>
-  <%= javascript_include_tag 'jquery.validate/localization/messages_' + I18n.locale.to_s.downcase.gsub('-', '') %>
-<% end %>

--- a/frontend/lib/spree/frontend/engine.rb
+++ b/frontend/lib/spree/frontend/engine.rb
@@ -7,7 +7,6 @@ module Spree
       initializer "spree.assets.precompile", group: :all do |app|
         app.config.assets.precompile += %w[
           spree/frontend/all*
-          jquery.validate/localization/messages_*
         ]
       end
 

--- a/frontend/spec/features/locale_spec.rb
+++ b/frontend/spec/features/locale_spec.rb
@@ -43,18 +43,5 @@ describe 'setting locale', type: :feature do
         expect(find("#b#{attr} label.error").text).to eq(text)
       end
     end
-
-    it 'shows translated jquery.validate error messages', js: true do
-      visit spree.root_path
-      click_link mug.name
-      click_button 'add-to-cart-button'
-      error_messages.each do |locale, message|
-        with_locale(locale) do
-          visit '/checkout/address'
-          find('.form-buttons input[type=submit]').click
-          check_error_text message
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
# What does this PR do

- Recreates [this commit from main spree repo](https://github.com/spree/spree/commit/69573f719eb3c7ba13981119c973ed4d7aa6d9c7) which we have yet to include in our fork.
- Removes a dependency on [jQuery Validate](https://jqueryvalidation.org/), and instead makes use of html5 validation on input fields.
- I have left the lib files as they were since it seems like there are some of our projects that reference this indirectly.